### PR TITLE
#91: Grade out knoppen in design

### DIFF
--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -8,11 +8,11 @@ export const colors = {
   borderColor: '#E9E9EA',
   button: {
     grey: {
-      background: '#D1D1D6',
+      background: '#AEAEB2',
       text: whiteColor,
     },
     greyClear: {
-      text: '#D1D1D6',
+      text: '#AEAEB2',
     },
     primary: {
       background: 'rgba(0, 122, 255, 1)',


### PR DESCRIPTION
De kleuren `grey` en `greyClear` worden maar op 1 plaats gebruikt: waar Guido de kleur aangepast wil hebben. Dus da's makkelijk :-)

![change](https://github.com/blue-10/Blue10-MobileApp/assets/1770318/ea1c5cfb-717e-44ef-a0c8-c0462551333f)
