### PR TITLE
#90: Bij acties zijn er diverse gebruikers te selecteren

### DIFF
--- a/src/api/InvoiceApi.ts
+++ b/src/api/InvoiceApi.ts
@@ -120,6 +120,17 @@ export class InvoiceApi extends ApiServiceRequests {
   }
 
   /**
+   * Get actions that you can do on a invoice.
+   */
+  public async getUsersForAction (invoiceId: string, actionId: number): Promise<GetActionsForInvoiceResponse> {
+    const { data } = await this.getAxios().get<GetActionsForInvoiceResponse>(
+      `/DocumentAction/GetActionInformation/?actionId=${actionId}&documentId=${invoiceId}&documentType=1`,
+    );
+
+    return data;
+  }
+
+  /**
    * Post new action to a invoice
    */
   public async postNewActions(params: PostNewActionParams): Promise<string> {


### PR DESCRIPTION
De lijst met gebruikers om aan een actie toe te wijzen is afhankelijk van de geselecteerde actie. Hier was nog geen rekening mee gehouden.

Nieuwe API methode geïmplementeerd om de lijst met gebruikers voor de gekozen actie voor een factuur op te halen.

- Indien geen actie is geselecteerd: knop is disabled
- Bij kiezen van actie: lijst met gebruikers wordt opgehaald
  - Tijdens laden van lijst met gebruikers: knop is disabled
  - Indien er nog geen gebruiker was geselecteerd voordat de actie werd gewijzigd:
    - Als de nieuwe response een suggestedUserId bevat wordt die automatisch geselecteerd
  - Indien er al wel een gebruiker was geselecteerd voordat de actie werd gewijzigd:
    - Als de gebruiker ook in de nieuwe lijst voor komt, blijft deze geselecteerd
    - Als de geselecteerde gebruiker niet in de nieuwe lijst voor komt, wordt de selectie gewist
